### PR TITLE
add link to ResourceType in Team, and only import owned resource types

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -171,7 +171,7 @@ class ImportController extends Controller
                         });
                         if ($belongsToTeam) {
 
-                            $rowData[$this->columnResourceName] = $resourceType->id;
+                            $rowData[$this->columnResourceName] = $resourceType ? $resourceType->id : null;
                             // Log::info("matched demand resource type {$resourceName} to {$resourceType->id}");
                             for ($i = 0; $i < count($monthYear); $i++) {
                                 $columnLetter = chr(ord($this->columnDataStart) + $i); // 'H' + i

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -42,6 +42,12 @@ class Team extends TeamworkTeam
         return $this->hasMany(Team::class, 'parent_team_id');
     }
 
+    
+    public function resourceType(): BelongsTo
+    {
+        return $this->belongsTo(ResourceType::class, 'resource_type');
+    }
+
     public static function allSubTeamResourceTypes(Team $parentTeam): array
     {
         $subTeams = $parentTeam->subTeams;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved import process to include only resource types owned by teams when creating or updating demand records.
  - Minor formatting and spacing adjustments for better readability in logs and conditionals.

- **New Features**
  - Enabled teams to be linked directly to resource types, enhancing data relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->